### PR TITLE
fix: remove external font imports

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,10 +2,7 @@
 <html lang="es">
 
 <head>
-  <!-- Preconnect Google Fonts -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-
+  <!-- Conexiones externas minimizadas para permitir builds offline -->
   <!-- Preconnect Firebase (reviews.json) -->
   <link rel="preconnect" href="https://espanhol-entre-amigos.firebaseio.com">
 
@@ -29,8 +26,6 @@
 <body>
   <app-root></app-root>
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Raleway&amp;display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Amatic+SC&amp;display=swap" rel="stylesheet">
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async="" src="https://www.googletagmanager.com/gtag/js?id=G-0G922NQS1C"></script>
   <script>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,9 +1,7 @@
 @use '@angular/material' as mat;
 
-// 1) (Opcional) Importa la fuente Raleway
-@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap');
-
-// 2) Configuración de tipografía
+// 1) Tipografía base
+// Se eliminó la importación remota para permitir builds offline.
 $custom-typography: mat.m2-define-typography-config(
   $font-family: 'Raleway, sans-serif'
 );


### PR DESCRIPTION
## Summary
- remove Google Fonts imports from global styles and index.html for offline builds

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project.)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: missing exports such as 'async' in @angular/core/testing)*
- `npx --yes lighthouse http://localhost:4200 --quiet --no-update-notifier --chrome-flags="--headless --no-sandbox" --output=json --output-path=./lighthouse-report.json` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lighthouse)*


------
https://chatgpt.com/codex/tasks/task_e_6898cdb41a28832ea26c39a3d86331aa